### PR TITLE
Separate Location and Bluetooth permissions

### DIFF
--- a/android-ktx/src/main/java/com/mirego/trikot/bluetooth/android/ktx/AndroidBluetoothManager.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/bluetooth/android/ktx/AndroidBluetoothManager.kt
@@ -1,4 +1,4 @@
-package mirego.trikot.bluetooth
+package com.mirego.trikot.bluetooth.android.ktx
 
 import android.Manifest
 import android.bluetooth.BluetoothAdapter
@@ -18,6 +18,8 @@ import com.mirego.trikot.bluetooth.BluetoothManager
 import com.mirego.trikot.bluetooth.BluetoothScanResult
 import com.mirego.trikot.streams.cancellable.CancellableManager
 import com.mirego.trikot.streams.reactive.Publishers
+import mirego.trikot.bluetooth.AndroidBluetoothScanResult
+import mirego.trikot.bluetooth.toBluetoothScanResult
 import org.reactivestreams.Publisher
 import java.util.Timer
 import java.util.UUID
@@ -27,13 +29,17 @@ class AndroidBluetoothManager(val context: Context) : BluetoothManager {
     private val bluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
 
     override val statePublisher = Publishers.behaviorSubject<BluetoothManager.State>()
-    override val hasPermissionPublisher = Publishers.behaviorSubject<Boolean>()
+    override val missingPermissionsPublisher = Publishers.behaviorSubject<List<BluetoothManager.Permission>>()
 
     fun refreshLocationPermission() {
-        hasPermissionPublisher.value = ContextCompat.checkSelfPermission(
+        missingPermissionsPublisher.value = if (ContextCompat.checkSelfPermission(
             context,
             Manifest.permission.ACCESS_FINE_LOCATION
-        ) == PackageManager.PERMISSION_GRANTED
+        ) == PackageManager.PERMISSION_GRANTED) {
+            listOf(BluetoothManager.Permission.LOCATION)
+        } else {
+            emptyList()
+        }
     }
 
     init {

--- a/bluetooth/src/commonMain/kotlin/com/mirego/trikot/bluetooth/BluetoothManager.kt
+++ b/bluetooth/src/commonMain/kotlin/com/mirego/trikot/bluetooth/BluetoothManager.kt
@@ -5,12 +5,17 @@ import org.reactivestreams.Publisher
 
 interface BluetoothManager {
     val statePublisher: Publisher<State>
-    val hasPermissionPublisher: Publisher<Boolean>
+    val missingPermissionsPublisher: Publisher<List<Permission>>
 
     fun scanForDevices(cancellableManager: CancellableManager, serviceUUIDs: List<String>): Publisher<List<BluetoothScanResult>>
 
     enum class State {
         ON,
         OFF
+    }
+
+    enum class Permission {
+        BLUETOOTH,
+        LOCATION
     }
 }

--- a/bluetooth/src/commonMain/kotlin/com/mirego/trikot/bluetooth/EmptyBluetoothManager.kt
+++ b/bluetooth/src/commonMain/kotlin/com/mirego/trikot/bluetooth/EmptyBluetoothManager.kt
@@ -6,7 +6,7 @@ import org.reactivestreams.Publisher
 
 class EmptyBluetoothManager : BluetoothManager {
     override val statePublisher = Publishers.behaviorSubject<BluetoothManager.State>()
-    override val hasPermissionPublisher = Publishers.behaviorSubject<Boolean>()
+    override val missingPermissionsPublisher = Publishers.behaviorSubject<List<BluetoothManager.Permission>>()
 
     override fun scanForDevices(
         cancellableManager: CancellableManager,

--- a/swift-extensions/TrikotBluetoothManager.swift
+++ b/swift-extensions/TrikotBluetoothManager.swift
@@ -27,9 +27,9 @@ public class TrikotBluetoothManager: NSObject, BluetoothManager, CBCentralManage
         }
     }
 
-    public lazy var hasPermissionPublisher = PublisherExtensionsKt.map(bluetoothStatePublisher) { (value: Any) in
+    public lazy var missingPermissionsPublisher = PublisherExtensionsKt.map(bluetoothStatePublisher) { (value: Any) in
         guard let centralManagerState = value as? CBManagerState else { return nil }
-        return centralManagerState != .unauthorized
+        return centralManagerState != .unauthorized ? [] : [BluetoothManagerPermission.bluetooth]
     }
 
     func refreshLocationPermission() {


### PR DESCRIPTION
## Description
Explain which permissions is missing for bluetooth to work

## Motivation and Context
As:
- Android needs Location permission for Bluetooth to be accessed
- iOS needs Bluetooth permission for Bluetooth to be accessed 

Its almost impossible with the current implementation to explain to the user which action should be executed for the Bluetooth to work. By explaining which permission is missing, we can now know if everything is in place to access the Bluetooth stack.

## How Has This Been Tested?
In a separate application.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
