### PR TITLE
Switch to using a serial dispatch queue

### DIFF
--- a/swift-extensions/TrikotBluetoothManager.swift
+++ b/swift-extensions/TrikotBluetoothManager.swift
@@ -3,7 +3,8 @@ import CoreBluetooth
 import Dispatch
 
 public class TrikotBluetoothManager: NSObject, BluetoothManager, CBCentralManagerDelegate {
-    private let dispatchQueue = DispatchQueue(label: "bluetooth-serial", qos: .background)
+    private static let QueueLabel = "bluetooth-serial"
+    private let dispatchQueue = DispatchQueue(label: TrikotBluetoothManager.QueueLabel, qos: .background)
     private lazy var centralManager = CBCentralManager(delegate: self, queue: dispatchQueue)
 
     private let scanResultpublisher = frozenBehaviorSubject()


### PR DESCRIPTION
The dispatch queue used for the `TrikotBluetoothManager` was concurrent since we used `DispatchQueue.global` instead of the main constructor. This created race condition issues since code was not executed sequentially. We now switch to a serial queue to prevent these issues.

## How Has This Been Tested?

This has been tested in our application (Airthings)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
