### PR TITLE
Prevent Bluetooth from automatically turning on on Android

### DIFF
--- a/android-ktx/src/main/java/com/mirego/trikot/bluetooth/android/ktx/AndroidBluetoothManager.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/bluetooth/android/ktx/AndroidBluetoothManager.kt
@@ -49,7 +49,7 @@ class AndroidBluetoothManager(val context: Context) : BluetoothManager {
         refreshLocationPermission()
         if (bluetoothAdapter != null) {
             statePublisher.value =
-                if (bluetoothAdapter.enable()) {
+                if (bluetoothAdapter.isEnabled) {
                     BluetoothManager.State.ON
                 } else {
                     BluetoothManager.State.OFF


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
On Android, Bluetooth was automatically turned on when initializing the `AndroidBluetoothManager.statePublisher` via `bluetoothAdapter.enable()`. The `statePublisher` should instead use `bluetoothAdapter.isEnabled` to prevent turning on Bluetooth without the user's consent.

## Motivation and Context
Bluetooth should never be enabled without direct user consent, as the [documentation says](https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#enable()) : 
```
Bluetooth should never be enabled without direct user consent.
If you want to turn on Bluetooth in order to create a wireless connection, you should use the ACTION_REQUEST_ENABLE Intent, which will raise a dialog that requests user permission to turn on Bluetooth.
The enable() method is provided only for applications that include a user interface for changing system settings, such as a "power manager" app.
```

We have to replace `bluetoothAdapter.enable()` with `bluetoothAdapter.isEnabled` in order to correctly set the state of the `statePublisher` without turning on Bluetooth automatically.

## How Has This Been Tested?
This has been tested in our application (Airthings).
The app should listen to the `AndroidBluetoothAdapter.statePublisher` and use the `ACTION_REQUEST_ENABLE` Intent or simply prompt the user to go to his settings to turn on Bluetooth.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
