### PR TITLE
Update mirego.release plugin to 2.0 to prevent build failure

### DIFF
--- a/bluetooth/build.gradle
+++ b/bluetooth/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-multiplatform'
     id 'org.jlleitschuh.gradle.ktlint'
-    id 'mirego.release' version '1.13'
+    id 'mirego.release' version '2.0'
     id 'mirego.publish' version '1.0'
 }
 


### PR DESCRIPTION
As mentionned [here](https://github.com/mirego/MiregoGradle/pull/100), using a BuildTask with the latest gradle version (6.*) fails if two projects in the hierarchy have the same name, which could cause our next build to fail with the following exception (which happened to trikot.foundation):

```
> Task :trikotFoundation:release FAILED
Task :trikotFoundation:release in trikotFoundation Finished
:trikotFoundation:release (Thread[Execution worker for ':' Thread 4,5,main]) completed. Took 13.111 secs.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':mirego-trikot.foundation-plugin_release:trikotFoundation:runBuildTasks'.
> Included build /Users/admin/Jenkins/jenkins-root/workspace/Mirego/trikot.foundation/mirego-trikot.foundation-plugin_release has build path :mirego-trikot.foundation-plugin_release:mirego-trikot.foundation-plugin_release which is the same as included build /Users/admin/Jenkins/jenkins-root/workspace/Mirego/trikot.foundation/mirego-trikot.foundation-plugin_release
```

The [same fix](https://github.com/mirego/trikot.foundation/pull/31) was applied to [trikot.foundation](https://github.com/mirego/trikot.foundation).