### PR TITLE
Update Kotlin to version 1.5.10 and add watchOS and macOS targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the library will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.2.0
+> 2021-06-10
+- Added watchOS and macOS targets
+- Updated Kotlin version to 1.5.10
+
 ## 2.1.0
 > 2021-05-10
 

--- a/bluetooth/build.gradle.kts
+++ b/bluetooth/build.gradle.kts
@@ -26,6 +26,8 @@ kotlin {
     ios()
     iosArm32("iosArm32")
     tvos()
+    watchos()
+    macosX64()
 
     sourceSets {
         all {
@@ -79,6 +81,22 @@ kotlin {
         }
 
         val tvosX64Main by getting {
+            dependsOn(nativeMain)
+        }
+
+        val watchos32Main by creating {
+            dependsOn(nativeMain)
+        }
+
+        val watchosArm64Main by getting {
+            dependsOn(nativeMain)
+        }
+
+        val watchosX64Main by getting {
+            dependsOn(nativeMain)
+        }
+
+        val macosX64Main by getting {
             dependsOn(nativeMain)
         }
     }

--- a/bluetooth/gradle.properties
+++ b/bluetooth/gradle.properties
@@ -1,2 +1,2 @@
 #Mon May 10 16:22:54 EDT 2021
-version=2.1.1-SNAPSHOT
+version=2.2.0-SNAPSHOT

--- a/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidAttributeProfileCharacteristic.kt
+++ b/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidAttributeProfileCharacteristic.kt
@@ -14,7 +14,7 @@ class AndroidAttributeProfileCharacteristic(
 ) : AttributeProfileCharacteristic {
     override val event = Publishers.publishSubject<AttributeProfileCharacteristicEvent>()
 
-    override val uuid: String = bluetoothGattCharacteristic.uuid.toString().toUpperCase(Locale.ROOT)
+    override val uuid: String = bluetoothGattCharacteristic.uuid.toString().uppercase(Locale.ROOT)
 
     override fun read() {
         bluetoothDevice.readCharacteristic(bluetoothGattCharacteristic)

--- a/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidAttributeProfileService.kt
+++ b/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidAttributeProfileService.kt
@@ -18,7 +18,7 @@ class AndroidAttributeProfileService(
         (
             mutableMapOf(
                 value.uuid.toString()
-                    .toUpperCase(Locale.ROOT) to
+                    .uppercase(Locale.ROOT) to
                     AndroidAttributeProfileCharacteristic(
                         value,
                         bluetoothDevice

--- a/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidBluetoothDevice.kt
+++ b/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidBluetoothDevice.kt
@@ -92,7 +92,7 @@ class AndroidBluetoothDevice(
                         ) { result, value ->
                             (
                                 mutableMapOf(
-                                    value.uuid.toString().toUpperCase(Locale.ROOT) to
+                                    value.uuid.toString().uppercase(Locale.ROOT) to
                                         AndroidAttributeProfileService(
                                             value,
                                             this@AndroidBluetoothDevice
@@ -159,8 +159,8 @@ class AndroidBluetoothDevice(
                     value: ByteArray?,
                     error: Throwable?
                 ) {
-                    val serviceId = characteristic.service.uuid.toString().toUpperCase(Locale.ROOT)
-                    val characteristicId = characteristic.uuid.toString().toUpperCase(Locale.ROOT)
+                    val serviceId = characteristic.service.uuid.toString().uppercase(Locale.ROOT)
+                    val characteristicId = characteristic.uuid.toString().uppercase(Locale.ROOT)
                     androidProfiles?.get(serviceId)
                         ?.androidCharacteristic?.get(characteristicId)?.event
                         ?.value = AttributeProfileCharacteristicEvent(value, error)

--- a/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/ScanResultExtensions.kt
+++ b/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/ScanResultExtensions.kt
@@ -12,6 +12,8 @@ import com.mirego.trikot.streams.reactive.map
 import org.reactivestreams.Publisher
 import java.util.Timer
 import kotlin.concurrent.schedule
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 import kotlin.time.minutes
 
@@ -60,7 +62,7 @@ class AndroidBluetoothScanResult(
         updateManufacturerData()
         rssiPublisher.value = scanResult.rssi
         timer = Timer().also {
-            it.schedule(1.minutes.inMilliseconds.toLong()) {
+            it.schedule(Duration.minutes(1).toLong(DurationUnit.MILLISECONDS)) {
                 lostHeartbeatCallback?.let {
                     it()
                 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:4.1.2")
+        classpath("com.android.tools.build:gradle:4.1.3")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${project.extra["kotlin_version"]}")
         classpath("org.jlleitschuh.gradle:ktlint-gradle:9.4.1")
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
-kotlin_version=1.5.0
-trikot_foundation_version=2.1.0
-trikot_streams_version=2.1.0
+kotlin_version=1.5.10
+trikot_foundation_version=2.2.1
+trikot_streams_version=2.2.0
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.mpp.stability.nowarn=true
 kotlin.native.enableDependencyPropagation=false


### PR DESCRIPTION
## 📖 Description
- Added watchOS and macOS targets
- Updated Kotlin version to 1.5.10

## 💭 Motivation and Context
macOS target was needed for a project

## 🧪 How Has This Been Tested?
`./gradlew build`

## 🦀 Dispatch
`#dispatch/kmp`