### PR TITLE
Fix usage of service from CBCharacteristic which is now optional

### DIFF
--- a/swift-extensions/TrikotBluetoothDevice.swift
+++ b/swift-extensions/TrikotBluetoothDevice.swift
@@ -29,7 +29,7 @@ class TrikotBluetoothDevice: NSObject, BluetoothDevice, CBPeripheralDelegate {
         physicalAddress = peripheral.identifier.uuidString
         super.init()
 
-        peripheral.delegate = self        
+        peripheral.delegate = self
     }
 
     func connect(cancellableManager: CancellableManager) {
@@ -66,22 +66,28 @@ class TrikotBluetoothDevice: NSObject, BluetoothDevice, CBPeripheralDelegate {
     }
 
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        guard let service = characteristic.service else { return }
+
         if let error = error {
-            services[characteristic.service]?.trikotCharacteristics[characteristic]?.newError = error
+            services[service]?.trikotCharacteristics[characteristic]?.newError = error
         } else {
-            services[characteristic.service]?.trikotCharacteristics[characteristic]?.newValue = characteristic.value
+            services[service]?.trikotCharacteristics[characteristic]?.newValue = characteristic.value
         }
     }
 
     func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
+        guard let service = characteristic.service else { return }
+
         if let error = error {
-            services[characteristic.service]?.trikotCharacteristics[characteristic]?.newError = error
+            services[service]?.trikotCharacteristics[characteristic]?.newError = error
         }
     }
 
     func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
+        guard let service = characteristic.service else { return }
+
         if let error = error {
-            services[characteristic.service]?.trikotCharacteristics[characteristic]?.newError = error
+            services[service]?.trikotCharacteristics[characteristic]?.newError = error
         }
     }
 }


### PR DESCRIPTION
## Description
With the new release of Xcode 13, the property `service` from `CBCharacteristic` is now optional, so we needed to add some guard clauses to protect the execution of unsafe code.

## Motivation and Context
These changes were necessary to support building on Xcode 13

## How Has This Been Tested?
The code has been tested in an app integrating this library

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
